### PR TITLE
Each function passes value or pointer to By rules

### DIFF
--- a/each.go
+++ b/each.go
@@ -78,10 +78,8 @@ func (r EachRule) getInterface(value reflect.Value) interface{} {
 		if value.IsNil() {
 			return nil
 		}
-		return value.Elem().Interface()
-	default:
-		return value.Interface()
 	}
+	return value.Interface()
 }
 
 func (r EachRule) getString(value reflect.Value) string {

--- a/each_test.go
+++ b/each_test.go
@@ -72,3 +72,16 @@ func TestEachWithContext(t *testing.T) {
 		assertError(t, test.err, err, test.tag)
 	}
 }
+
+func TestEachAndBy(t *testing.T) {
+	var byAddr bool
+	var s string
+	Each(By(func(v interface{}) error {
+		_, byAddr = v.(*string)
+		return nil
+	})).Validate([]*string{&s})
+
+	if !byAddr {
+		t.Fatal("slice of pointers does not get passed to `By` function by ref")
+	}
+}

--- a/each_test.go
+++ b/each_test.go
@@ -76,7 +76,7 @@ func TestEachWithContext(t *testing.T) {
 func TestEachAndBy(t *testing.T) {
 	var byAddr bool
 	var s string
-	Each(By(func(v interface{}) error {
+	_ = Each(By(func(v interface{}) error {
 		_, byAddr = v.(*string)
 		return nil
 	})).Validate([]*string{&s})


### PR DESCRIPTION
This is a copy of https://github.com/go-ozzo/ozzo-validation/pull/160

As per the original PR:

The combination of Elem().Interface() does not return a pointer, even if the original variable was a pointer. Passing by value to validation rules becomes a problem when the value is a struct with a private mutex. This is the case with structs generated with protoc-gen-go. go vet -copylocks illustrates the problem.

I acknowledge this may be a breaking change for some. If they have written custom rules, the rules receive an empty interface and have to cast the argument to the appropriate type. This argument will be a pointer in cases where it previously wasn't.