### PR TITLE
Updating Minimum Go version and workflows for testing

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,9 +13,15 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+        id: go
 
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.46
+          version: v1.58

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,24 +1,24 @@
 name: Test Go
 on: [push, pull_request]
 jobs:
-  lint-test-build:
-    name: Lint, Test
+  test:
+    name: Test
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: '1.16.2'
-      id: go
+      - name: Check out code
+        uses: actions/checkout@v3
 
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+        id: go
 
-    - name: Install Dependencies
-      env:
-        GOPROXY: https://proxy.golang.org,direct
-      run: go mod download
+      - name: Install Dependencies
+        env:
+          GOPROXY: https://proxy.golang.org,direct
+        run: go mod download
 
-    - name: Test
-      run: go test -tags unit -race ./...
+      - name: Test
+        run: go test -tags unit -race ./...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,31 @@
+run:
+  timeout: "120s"
+
+output:
+  formats:
+    - format: "colored-line-number"
+
+linters:
+  enable:
+    - "gocyclo"
+    - "unconvert"
+    - "goimports"
+    - "govet"
+    - "misspell"
+    - "nakedret"
+    - "revive"
+    - "goconst"
+    - "unparam"
+    - "gofmt"
+
+linters-settings:
+  staticcheck:
+    # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
+    # Default: ["*"]
+    checks: ["all"]
+
+  goconst:
+    ignore-tests: true
+
+issues:
+  exclude-use-default: false

--- a/date.go
+++ b/date.go
@@ -25,9 +25,10 @@ type DateRule struct {
 // Date returns a validation rule that checks if a string value is in a format that can be parsed into a date.
 // The format of the date should be specified as the layout parameter which accepts the same value as that for time.Parse.
 // For example,
-//    validation.Date(time.ANSIC)
-//    validation.Date("02 Jan 06 15:04 MST")
-//    validation.Date("2006-01-02")
+//
+//	validation.Date(time.ANSIC)
+//	validation.Date("02 Jan 06 15:04 MST")
+//	validation.Date("2006-01-02")
 //
 // By calling Min() and/or Max(), you can let the Date rule to check if a parsed date value is within
 // the specified date range.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,14 @@
 module github.com/invopop/validation
 
-go 1.16
+go 1.20
 
 require (
-	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
+	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/stretchr/testify v1.8.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
-github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
-github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
-github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
+github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/validation.go
+++ b/validation.go
@@ -60,11 +60,11 @@ var (
 // Validate validates the given value and returns the validation error, if any.
 //
 // Validate performs validation using the following steps:
-// 1. For each rule, call its `Validate()` to validate the value. Return if any error is found.
-// 2. If the value being validated implements `Validatable`, call the value's `Validate()`.
-//    Return with the validation result.
-// 3. If the value being validated is a map/slice/array, and the element type implements `Validatable`,
-//    for each element call the element value's `Validate()`. Return with the validation result.
+//  1. For each rule, call its `Validate()` to validate the value. Return if any error is found.
+//  2. If the value being validated implements `Validatable`, call the value's `Validate()`.
+//     Return with the validation result.
+//  3. If the value being validated is a map/slice/array, and the element type implements `Validatable`,
+//     for each element call the element value's `Validate()`. Return with the validation result.
 func Validate(value interface{}, rules ...Rule) error {
 	for _, rule := range rules {
 		if s, ok := rule.(skipRule); ok && s.skip {
@@ -103,16 +103,16 @@ func Validate(value interface{}, rules ...Rule) error {
 // ValidateWithContext validates the given value with the given context and returns the validation error, if any.
 //
 // ValidateWithContext performs validation using the following steps:
-// 1. For each rule, call its `ValidateWithContext()` to validate the value if the rule implements `RuleWithContext`.
-//    Otherwise call `Validate()` of the rule. Return if any error is found.
-// 2. If the value being validated implements `ValidatableWithContext`, call the value's `ValidateWithContext()`
-//    and return with the validation result.
-// 3. If the value being validated implements `Validatable`, call the value's `Validate()`
-//    and return with the validation result.
-// 4. If the value being validated is a map/slice/array, and the element type implements `ValidatableWithContext`,
-//    for each element call the element value's `ValidateWithContext()`. Return with the validation result.
-// 5. If the value being validated is a map/slice/array, and the element type implements `Validatable`,
-//    for each element call the element value's `Validate()`. Return with the validation result.
+//  1. For each rule, call its `ValidateWithContext()` to validate the value if the rule implements `RuleWithContext`.
+//     Otherwise call `Validate()` of the rule. Return if any error is found.
+//  2. If the value being validated implements `ValidatableWithContext`, call the value's `ValidateWithContext()`
+//     and return with the validation result.
+//  3. If the value being validated implements `Validatable`, call the value's `Validate()`
+//     and return with the validation result.
+//  4. If the value being validated is a map/slice/array, and the element type implements `ValidatableWithContext`,
+//     for each element call the element value's `ValidateWithContext()`. Return with the validation result.
+//  5. If the value being validated is a map/slice/array, and the element type implements `Validatable`,
+//     for each element call the element value's `Validate()`. Return with the validation result.
 func ValidateWithContext(ctx context.Context, value interface{}, rules ...Rule) error {
 	for _, rule := range rules {
 		if s, ok := rule.(skipRule); ok && s.skip {


### PR DESCRIPTION
* Upgrade Go to minimum 1.20 (current last supported version)
* Updating linter and test workflow configs.