### PR TITLE
Fix: panic for nil entries in a slice

### DIFF
--- a/each_test.go
+++ b/each_test.go
@@ -33,7 +33,6 @@ func TestEach(t *testing.T) {
 		{"t13", []interface{}{nil, a}, "0: cannot be blank; 1: cannot be blank."},
 		{"t14", []interface{}{c0, c1, f}, "0: cannot be blank."},
 	}
-
 	for _, test := range tests {
 		r := Each(Required)
 		err := r.Validate(test.value)

--- a/validation.go
+++ b/validation.go
@@ -199,7 +199,11 @@ func validateSlice(rv reflect.Value) error {
 	errs := Errors{}
 	l := rv.Len()
 	for i := 0; i < l; i++ {
-		if ev := rv.Index(i).Interface(); ev != nil {
+		v := rv.Index(i)
+		if v.Kind() == reflect.Ptr && v.IsNil() {
+			continue
+		}
+		if ev := v.Interface(); ev != nil {
 			if err := ev.(Validatable).Validate(); err != nil {
 				errs[strconv.Itoa(i)] = err
 			}
@@ -216,7 +220,11 @@ func validateSliceWithContext(ctx context.Context, rv reflect.Value) error {
 	errs := Errors{}
 	l := rv.Len()
 	for i := 0; i < l; i++ {
-		if ev := rv.Index(i).Interface(); ev != nil {
+		v := rv.Index(i)
+		if v.Kind() == reflect.Ptr && v.IsNil() {
+			continue
+		}
+		if ev := v.Interface(); ev != nil {
 			if err := ev.(ValidatableWithContext).ValidateWithContext(ctx); err != nil {
 				errs[strconv.Itoa(i)] = err
 			}

--- a/validation_test.go
+++ b/validation_test.go
@@ -217,8 +217,10 @@ func (s String123) Validate() error {
 
 type Model2 struct {
 	Model3
-	M3 Model3
-	B  string
+	M3   Model3
+	M3AP []*Model3
+	M4AP []*Model4
+	B    string
 }
 
 type Model3 struct {


### PR DESCRIPTION
Fixes a panic generated when validating slices with nil entries:

```go
type Address struct {
  Street string
}
type Party struct {
  Name string
  Addresses []*Address
}
func (a *Address) Validate() error {
  return validation.ValidateStruct(a, validation.Field(&a.Street, validation.Required))
}

p := &Party{
  Addresses: []*Address{nil},
}
validation.ValidateStruct(p, validation.Field(&p.Addresses)) // this would panic
```