### PR TITLE
Enable gofumpt linter; clean up formatting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,7 @@ linters:
     - "revive"
     - "goconst"
     - "unparam"
-    - "gofmt"
+    - "gofumpt"
 
 linters-settings:
   staticcheck:

--- a/each_test.go
+++ b/each_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestEach(t *testing.T) {
 	var a *int
-	var f = func(v string) string { return v }
+	f := func(v string) string { return v }
 	var c0 chan int
 	c1 := make(chan int)
 

--- a/in_test.go
+++ b/in_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestIn(t *testing.T) {
-	var v = 1
+	v := 1
 	var v2 *int
 	tests := []struct {
 		tag    string
@@ -38,7 +38,7 @@ func TestIn(t *testing.T) {
 }
 
 func TestIn_Generics(t *testing.T) {
-	var v = "a"
+	v := "a"
 	var v2 *string
 	tests := []struct {
 		tag    string

--- a/minmax.go
+++ b/minmax.go
@@ -46,7 +46,6 @@ func Min(min interface{}) ThresholdRule {
 		operator:  greaterEqualThan,
 		err:       ErrMinGreaterEqualThanRequired,
 	}
-
 }
 
 // Max returns a validation rule that checks if a value is less or equal than the specified value.

--- a/multipleof_test.go
+++ b/multipleof_test.go
@@ -23,7 +23,6 @@ func TestMultipleOf(t *testing.T) {
 	assert.Equal(t, "must be multiple of 10", r3.Validate(uint(11)).Error())
 	assert.Equal(t, nil, r3.Validate(uint(20)))
 	assert.Equal(t, "cannot convert float32 to uint64", r3.Validate(float32(20)).Error())
-
 }
 
 func Test_MultipleOf_Error(t *testing.T) {

--- a/not_in_test.go
+++ b/not_in_test.go
@@ -13,7 +13,7 @@ import (
 func TestNotIn(t *testing.T) {
 	v := 1
 	var v2 *int
-	var tests = []struct {
+	tests := []struct {
 		tag    string
 		values []interface{}
 		value  interface{}
@@ -39,7 +39,7 @@ func TestNotIn(t *testing.T) {
 func TestNotIn_Ints(t *testing.T) {
 	v := 1
 	var v2 *int
-	var tests = []struct {
+	tests := []struct {
 		tag    string
 		values []int
 		value  any

--- a/struct.go
+++ b/struct.go
@@ -12,10 +12,8 @@ import (
 	"strings"
 )
 
-var (
-	// ErrStructPointer is the error that a struct being validated is not specified as a pointer.
-	ErrStructPointer = errors.New("only a pointer to a struct can be validated")
-)
+// ErrStructPointer is the error that a struct being validated is not specified as a pointer.
+var ErrStructPointer = errors.New("only a pointer to a struct can be validated")
 
 type (
 	// ErrFieldPointer is the error that a field is not specified as a pointer.

--- a/struct_test.go
+++ b/struct_test.go
@@ -178,7 +178,7 @@ func TestValidateStructWithContext(t *testing.T) {
 		assertError(t, test.err, err, test.tag)
 	}
 
-	//embedded struct
+	// embedded struct
 	err := ValidateWithContext(context.Background(), &m3)
 	if assert.NotNil(t, err) {
 		assert.Equal(t, "A: error abc.", err.Error())

--- a/util_test.go
+++ b/util_test.go
@@ -193,7 +193,7 @@ func TestToFloat(t *testing.T) {
 
 func TestIsEmpty(t *testing.T) {
 	var s1 string
-	var s2 = "a"
+	s2 := "a"
 	var s3 *string
 	s4 := struct{}{}
 	time1 := time.Now()
@@ -267,7 +267,7 @@ func TestIsEmpty(t *testing.T) {
 }
 
 func TestIndirect(t *testing.T) {
-	var a = 100
+	a := 100
 	var b *int
 	var c *sql.NullInt64
 


### PR DESCRIPTION
The PR replaces `gofmt` with [`gofumpt`](https://github.com/mvdan/gofumpt) linter as the latter is stricter. It can find unnecessary empty lines, redundant var declarations, etc.